### PR TITLE
refactor: bump svelte, prettier dependencies

### DIFF
--- a/integration/multi-export/COMPONENT_INDEX.md
+++ b/integration/multi-export/COMPONENT_INDEX.md
@@ -54,7 +54,7 @@ None.
 ### Types
 
 ```ts
-type Author = string;
+export type Author = string;
 ```
 
 ### Props

--- a/integration/multi-export/types/Quote.d.ts
+++ b/integration/multi-export/types/Quote.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="svelte" />
 
-type Author = string;
+export type Author = string;
 
 export interface QuoteProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
   /**

--- a/integration/single-export/types/index.d.ts
+++ b/integration/single-export/types/index.d.ts
@@ -1,2 +1,2 @@
 export { default as Button } from "./Button";
-export { default } from "./Button";
+export { default as default } from "./Button";

--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "comment-parser": "^0.7.6",
     "fs-extra": "^9.0.1",
-    "prettier": "^2.1.2",
+    "prettier": "^2.2.0",
     "rollup": "^2.33.3",
     "rollup-plugin-svelte": "^6.1.1",
-    "svelte": "^3.29.7"
+    "svelte": "^3.30.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.4",
-    "@types/node": "^14.14.8",
+    "@types/node": "^14.14.10",
     "@types/prettier": "^2.1.5",
     "@types/tape": "^4.13.0",
     "npm-run-all": "^4.1.5",
-    "svelte-check": "^1.1.14",
+    "svelte-check": "^1.1.17",
     "tape": "^5.0.1",
     "ts-node-dev": "^1.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.2"
   },
   "bin": {
     "sveld": "./cli.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz#e1c09064121f894baaad2bd9f12ce4a41bffb274"
   integrity sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ==
 
-"@types/node@^14.14.8":
-  version "14.14.8"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz#2127bd81949a95c8b7d3240f3254352d72563aec"
-  integrity sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==
+"@types/node@^14.14.10":
+  version "14.14.10"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
+  integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
 "@types/prettier@^2.1.5":
   version "2.1.5"
@@ -1001,10 +1001,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-prettier@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+prettier@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
+  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -1292,10 +1292,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svelte-check@^1.1.14:
-  version "1.1.14"
-  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-1.1.14.tgz#e6d94607b8d2e2e8738fbef39fe2f540f09a12b7"
-  integrity sha512-Vx/Nfesn29sRTsc7DJ9bAoTWT+gA+6ZWSiC+G+FMjWac2NP0CpNXdD0tjVvlztZY7HZNxya6D/QyNtCGFC9K6Q==
+svelte-check@^1.1.17:
+  version "1.1.17"
+  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-1.1.17.tgz#8faec43882bf9b1bf98105df33a13347bd49b70d"
+  integrity sha512-5JDQyKQWtxfA0lzPKrv2F3n7zBoij0mpVaW6nrU+Zc4GsjjPepMRTDyJVGiD+hyUqebnx7RShIBnwJB6neLuOQ==
   dependencies:
     chalk "^4.0.0"
     chokidar "^3.4.1"
@@ -1316,10 +1316,10 @@ svelte-preprocess@^4.0.0:
     detect-indent "^6.0.0"
     strip-indent "^3.0.0"
 
-svelte@^3.29.7:
-  version "3.29.7"
-  resolved "https://registry.npmjs.org/svelte/-/svelte-3.29.7.tgz#e254eb2d0d609ce0fd60f052d444ac4a66d90f7d"
-  integrity sha512-rx0g311kBODvEWUU01DFBUl3MJuJven04bvTVFUG/w0On/wuj0PajQY/QlXcJndFxG+W1s8iXKaB418tdHWc3A==
+svelte@^3.30.0:
+  version "3.30.0"
+  resolved "https://registry.npmjs.org/svelte/-/svelte-3.30.0.tgz#cbde341e96bf34f4ac73c8f14f8a014e03bfb7d6"
+  integrity sha512-z+hdIACb9TROGvJBQWcItMtlr4s0DBUgJss6qWrtFkOoIInkG+iAMo/FJZQFyDBQZc+dul2+TzYSi/tpTT5/Ag==
 
 tape@^5.0.1:
   version "5.0.1"
@@ -1404,10 +1404,15 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-typescript@*, typescript@^4.0.5:
+typescript@*:
   version "4.0.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 universalify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Changes**

- upgrade svelte to version 3.30
- refactor `ComponentParser.ts` to use exported svelte compiler walk interface
- upgrade prettier to version 2.2