### PR TITLE
Use acorn to parse exports, use fast-glob to obtain Svelte component files from source folder

### DIFF
--- a/integration/multi-export-typed/COMPONENT_API.json
+++ b/integration/multi-export-typed/COMPONENT_API.json
@@ -3,7 +3,7 @@
   "components": [
     {
       "moduleName": "Button",
-      "filePath": "/src/Button.svelte",
+      "filePath": "src/Button.svelte",
       "props": [
         {
           "name": "type",
@@ -38,35 +38,8 @@
       "rest_props": { "type": "Element", "name": "button" }
     },
     {
-      "moduleName": "SecondaryButton",
-      "filePath": "/src/SecondaryButton.svelte",
-      "props": [
-        {
-          "name": "secondary",
-          "kind": "const",
-          "type": "boolean",
-          "value": "true",
-          "isFunction": false,
-          "constant": true,
-          "reactive": false
-        }
-      ],
-      "slots": [
-        {
-          "name": "__default__",
-          "default": true,
-          "fallback": "Click me",
-          "slot_props": "{}"
-        }
-      ],
-      "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],
-      "typedefs": [],
-      "rest_props": { "type": "InlineComponent", "name": "Button" },
-      "extends": { "interface": "ButtonProps", "import": "\"./Button\"" }
-    },
-    {
       "moduleName": "Link",
-      "filePath": "/src/Link.svelte",
+      "filePath": "src/Link.svelte",
       "props": [],
       "slots": [
         {
@@ -82,7 +55,7 @@
     },
     {
       "moduleName": "Quote",
-      "filePath": "/src/Quote.svelte",
+      "filePath": "src/Quote.svelte",
       "props": [
         {
           "name": "quote",
@@ -114,6 +87,33 @@
       "events": [],
       "typedefs": [],
       "rest_props": { "type": "Element", "name": "blockquote" }
+    },
+    {
+      "moduleName": "SecondaryButton",
+      "filePath": "src/SecondaryButton.svelte",
+      "props": [
+        {
+          "name": "secondary",
+          "kind": "const",
+          "type": "boolean",
+          "value": "true",
+          "isFunction": false,
+          "constant": true,
+          "reactive": false
+        }
+      ],
+      "slots": [
+        {
+          "name": "__default__",
+          "default": true,
+          "fallback": "Click me",
+          "slot_props": "{}"
+        }
+      ],
+      "events": [{ "type": "forwarded", "name": "click", "element": "Button" }],
+      "typedefs": [],
+      "rest_props": { "type": "InlineComponent", "name": "Button" },
+      "extends": { "interface": "ButtonProps", "import": "\"./Button\"" }
     }
   ]
 }

--- a/integration/multi-export-typed/types/Button.d.ts
+++ b/integration/multi-export-typed/types/Button.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+export interface ButtonProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
    * @default "button"
    */

--- a/integration/multi-export-typed/types/Link.d.ts
+++ b/integration/multi-export-typed/types/Link.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface LinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+export interface LinkProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export-typed/types/Quote.d.ts
+++ b/integration/multi-export-typed/types/Quote.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface QuoteProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+export interface QuoteProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
   /**
    * @default ""
    */
@@ -13,4 +14,8 @@ export interface QuoteProps extends svelte.JSX.HTMLAttributes<HTMLElementTagName
   author?: string;
 }
 
-export default class Quote extends SvelteComponentTyped<QuoteProps, {}, { default: {} }> {}
+export default class Quote extends SvelteComponentTyped<
+  QuoteProps,
+  {},
+  { default: {} }
+> {}

--- a/integration/multi-export/COMPONENT_API.json
+++ b/integration/multi-export/COMPONENT_API.json
@@ -3,7 +3,7 @@
   "components": [
     {
       "moduleName": "Button",
-      "filePath": "/src/Button.svelte",
+      "filePath": "src/Button.svelte",
       "props": [
         {
           "name": "type",
@@ -38,7 +38,7 @@
     },
     {
       "moduleName": "Link",
-      "filePath": "/src/Link.svelte",
+      "filePath": "src/Link.svelte",
       "props": [],
       "slots": [
         {
@@ -54,7 +54,7 @@
     },
     {
       "moduleName": "Quote",
-      "filePath": "/src/Quote.svelte",
+      "filePath": "src/Quote.svelte",
       "props": [
         {
           "name": "quote",

--- a/integration/multi-export/types/Button.d.ts
+++ b/integration/multi-export/types/Button.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+export interface ButtonProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
    * @default "button"
    */

--- a/integration/multi-export/types/Link.d.ts
+++ b/integration/multi-export/types/Link.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface LinkProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
+export interface LinkProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["a"]> {}
 
 export default class Link extends SvelteComponentTyped<
   LinkProps,

--- a/integration/multi-export/types/Quote.d.ts
+++ b/integration/multi-export/types/Quote.d.ts
@@ -3,7 +3,8 @@ import { SvelteComponentTyped } from "svelte";
 
 export type Author = string;
 
-export interface QuoteProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
+export interface QuoteProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["blockquote"]> {
   /**
    * @default ""
    */
@@ -15,4 +16,8 @@ export interface QuoteProps extends svelte.JSX.HTMLAttributes<HTMLElementTagName
   author?: Author;
 }
 
-export default class Quote extends SvelteComponentTyped<QuoteProps, {}, { default: {} }> {}
+export default class Quote extends SvelteComponentTyped<
+  QuoteProps,
+  {},
+  { default: {} }
+> {}

--- a/integration/single-export/COMPONENT_API.json
+++ b/integration/single-export/COMPONENT_API.json
@@ -3,7 +3,7 @@
   "components": [
     {
       "moduleName": "Button",
-      "filePath": "/component/Button.svelte",
+      "filePath": "component/Button.svelte",
       "props": [
         {
           "name": "type",

--- a/integration/single-export/test/test.svelte
+++ b/integration/single-export/test/test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from "../component";
+  import Button, { Button as Button2 } from "../component";
 </script>
 
 <Button
@@ -10,3 +10,12 @@
   }}>
   Text
 </Button>
+
+<Button2
+  style="color: red"
+  primary={false}
+  on:click={(e) => {
+    console.log(e);
+  }}>
+  Text
+</Button2>

--- a/integration/single-export/types/Button.d.ts
+++ b/integration/single-export/types/Button.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
-export interface ButtonProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
+export interface ButtonProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["button"]> {
   /**
    * @default "button"
    */

--- a/integration/single-export/types/index.d.ts
+++ b/integration/single-export/types/index.d.ts
@@ -1,2 +1,2 @@
 export { default as Button } from "./Button";
-export { default as default } from "./Button";
+export { default } from "./Button";

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^11.0.1",
+    "acorn": "^8.0.4",
     "comment-parser": "^0.7.6",
     "fs-extra": "^9.0.1",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rollup/plugin-node-resolve": "^11.0.1",
     "acorn": "^8.0.4",
     "comment-parser": "^0.7.6",
+    "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.1",
     "prettier": "^2.2.1",
     "rollup": "^2.36.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,8 @@
 import * as Rollup from "rollup";
-import * as fs from "fs";
-import * as path from "path";
 import * as svelte from "rollup-plugin-svelte";
 import resolve from "@rollup/plugin-node-resolve";
 import { generateBundle, PluginSveldOptions, writeOutput } from "./rollup-plugin";
-
-function getSvelteEntry() {
-  try {
-    const pkg_path = path.join(process.cwd(), "package.json");
-    const pkg = JSON.parse(fs.readFileSync(pkg_path, "utf-8"));
-    return pkg.svelte;
-  } catch (e) {
-    process.stderr.write(e + "\n");
-    return null;
-  }
-}
+import { getSvelteEntry } from "./get-svelte-entry";
 
 export async function cli(process: NodeJS.Process) {
   const options: PluginSveldOptions = process.argv

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,10 +24,9 @@ export async function cli(process: NodeJS.Process) {
     ],
   });
 
-  const { output } = await rollup_bundle.generate({});
+  await rollup_bundle.generate({});
 
-  // @ts-ignore
-  const result = await generateBundle(output, input);
+  const result = await generateBundle(input);
 
   writeOutput(result, options, input);
 }

--- a/src/create-exports.ts
+++ b/src/create-exports.ts
@@ -3,11 +3,25 @@ import { ParsedExports } from "./parse-exports";
 export function createExports(parsed_exports: ParsedExports): string {
   const source = Object.entries(parsed_exports).map(([id, exportee]) => {
     if (id === "default" || exportee.default) {
-      return `export { default } from "${exportee.source}";`;
+      if (exportee.mixed) {
+        return `export { default as ${id} } from "${removeSvelteExt(
+          exportee.source
+        )}";\nexport { default } from "${removeSvelteExt(exportee.source)}";`;
+      }
+
+      return `export { default } from "${removeSvelteExt(exportee.source)}";`;
     }
 
-    return `export { default as ${id} } from "${exportee.source}";`;
+    return `export { default as ${id} } from "${removeSvelteExt(exportee.source)}";`;
   });
 
   return source.join("\n");
+}
+
+export function removeSvelteExt(filePath: string): string {
+  return filePath.replace(/\.svelte$/, "");
+}
+
+export function convertSvelteExt(filePath: string): string {
+  return filePath.replace(/\.svelte$/, ".d.ts");
 }

--- a/src/create-exports.ts
+++ b/src/create-exports.ts
@@ -1,0 +1,13 @@
+import { ParsedExports } from "./parse-exports";
+
+export function createExports(parsed_exports: ParsedExports): string {
+  const source = Object.entries(parsed_exports).map(([id, exportee]) => {
+    if (id === "default" || exportee.default) {
+      return `export { default } from "${exportee.source}";`;
+    }
+
+    return `export { default as ${id} } from "${exportee.source}";`;
+  });
+
+  return source.join("\n");
+}

--- a/src/get-svelte-entry.ts
+++ b/src/get-svelte-entry.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export type SvelteEntryPoint = string;
+
+/**
+ * Get the file path entrypoint for uncompiled Svelte source code
+ * Expects a "svelte" field in the consumer's `package.json`
+ */
+export function getSvelteEntry(): SvelteEntryPoint | null {
+  const pkg_path = path.join(process.cwd(), "package.json");
+
+  if (fs.existsSync(pkg_path)) {
+    const pkg: { svelte?: SvelteEntryPoint } = JSON.parse(fs.readFileSync(pkg_path, "utf-8"));
+
+    if (pkg.svelte !== undefined) return pkg.svelte;
+
+    process.stdout.write("Could not determine an entrypoint.\n");
+    process.stdout.write('Specify an entrypoint to your Svelte code in the "svelte" field of your package.json.\n');
+    return null;
+  } else {
+    process.stdout.write("Could not locate a package.json file.\n");
+    return null;
+  }
+}

--- a/src/get-svelte-files.ts
+++ b/src/get-svelte-files.ts
@@ -1,0 +1,27 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as glob from "fast-glob";
+import { SvelteEntryPoint } from "./get-svelte-entry";
+
+interface SvelteFile {
+  filePath: string;
+  moduleName: string;
+}
+
+/**
+ * Get an array of Svelte files for a specified entrypoint
+ */
+export function getSvelteFiles(entry: SvelteEntryPoint): SvelteFile[] {
+  const dir = fs.lstatSync(entry).isFile() ? path.dirname(entry) : entry;
+
+  return glob.sync([`${dir}/**/*.svelte`]).map((filePath) => {
+    const { name } = path.parse(filePath);
+
+    return {
+      filePath,
+
+      // TODO: [refactor] normalize Svelte component name to follow Pascal case capitalization
+      moduleName: name,
+    };
+  });
+}

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -1,0 +1,57 @@
+import * as acorn from "acorn";
+
+interface NodeImportDeclaration extends acorn.Node {
+  type: "ImportDeclaration";
+  specifiers: [{ local: { name: string } }];
+  source: { value: string };
+}
+
+interface NodeExportNamedDeclaration extends acorn.Node, Pick<NodeImportDeclaration, "source"> {
+  type: "ExportNamedDeclaration";
+  specifiers: [{ local: { name: string }; exported: { name: string } }];
+}
+
+interface NodeExportDefaultDeclaration extends acorn.Node {
+  type: "ExportDefaultDeclaration";
+  declaration: { name: string };
+}
+
+type BodyNode = NodeImportDeclaration | NodeExportNamedDeclaration | NodeExportDefaultDeclaration;
+
+export function parseExports(source: string) {
+  const ast = acorn.parse(source, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  });
+
+  const exports_by_identifier: Record<string, { source?: string; default: boolean }> = {};
+
+  // @ts-ignore
+  ast.body.forEach((node: BodyNode) => {
+    if (node.type === "ExportDefaultDeclaration") {
+      const id = node.declaration.name;
+
+      if (id in exports_by_identifier) {
+        exports_by_identifier[id].default = true;
+      } else {
+        exports_by_identifier[id] = { default: true };
+      }
+    }
+
+    if (node.type === "ImportDeclaration" || node.type === "ExportNamedDeclaration") {
+      const exported_name = node.type === "ExportNamedDeclaration" ? node.specifiers[0].exported?.name : undefined;
+      const id = exported_name || node.specifiers[0].local.name;
+
+      if (id in exports_by_identifier) {
+        exports_by_identifier[id].source = node.source.value;
+      } else {
+        exports_by_identifier[id] = {
+          source: node.source.value,
+          default: id === "default",
+        };
+      }
+    }
+  });
+
+  return exports_by_identifier;
+}

--- a/src/parse-exports.ts
+++ b/src/parse-exports.ts
@@ -18,13 +18,15 @@ interface NodeExportDefaultDeclaration extends acorn.Node {
 
 type BodyNode = NodeImportDeclaration | NodeExportNamedDeclaration | NodeExportDefaultDeclaration;
 
+export type ParsedExports = Record<string, { source?: string; default: boolean }>;
+
 export function parseExports(source: string) {
   const ast = acorn.parse(source, {
     ecmaVersion: "latest",
     sourceType: "module",
   });
 
-  const exports_by_identifier: Record<string, { source?: string; default: boolean }> = {};
+  const exports_by_identifier: ParsedExports = {};
 
   // @ts-ignore
   ast.body.forEach((node: BodyNode) => {

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -1,10 +1,12 @@
-import * as Rollup from "rollup";
 import * as fs from "fs-extra";
 import * as path from "path";
 import writeTsDefinitions, { WriteTsDefinitionsOptions } from "./writer/writer-ts-definitions";
 import writeJson, { WriteJsonOptions } from "./writer/writer-json";
 import writeMarkdown, { WriteMarkdownOptions } from "./writer/writer-markdown";
 import ComponentParser, { ParsedComponent } from "./ComponentParser";
+import { getSvelteEntry } from "./get-svelte-entry";
+import { ParsedExports, parseExports } from "./parse-exports";
+import { getSvelteFiles } from "./get-svelte-files";
 
 export interface PluginSveldOptions {
   types?: boolean;
@@ -26,84 +28,50 @@ export type ComponentDocs = Map<ComponentModuleName, ComponentDocApi>;
 
 export default function pluginSveld(opts?: PluginSveldOptions) {
   let result: GenerateBundleResult;
-  let input: string;
+  let input: string | null;
 
   return {
     name: "plugin-sveld",
-    buildStart(options: Rollup.InputOptions) {
-      if (options.input) {
-        input = Array.isArray(options.input) ? options.input[0] : (options.input as string);
+    buildStart() {
+      input = getSvelteEntry();
+    },
+    async generateBundle() {
+      if (input != null) {
+        result = await generateBundle(input);
       }
     },
-    async generateBundle({}, bundle: Rollup.OutputBundle) {
-      result = await generateBundle(bundle, input);
-    },
     writeBundle() {
-      writeOutput(result, opts || {}, input);
+      if (input != null) writeOutput(result, opts || {}, input);
     },
   };
 }
 
 interface GenerateBundleResult {
-  exports: string[];
-  rendered_exports: string[];
-  default_export: { moduleName: null | string; only: boolean };
+  exports: ParsedExports;
   components: ComponentDocs;
 }
 
-export async function generateBundle(bundle: Rollup.OutputBundle, input: string) {
-  let exports: string[] = [];
-  let rendered_exports: string[] = [];
-  let default_export: { moduleName: null | string; only: boolean } = {
-    moduleName: null,
-    only: false,
-  };
-  let components: ComponentDocs = new Map();
-
+export async function generateBundle(input: string) {
+  const entry = fs.readFileSync(input, "utf-8");
+  const exports = parseExports(entry);
+  const components: ComponentDocs = new Map();
   const parser = new ComponentParser();
 
-  for (const filename in bundle) {
-    const chunkOrAsset = bundle[filename];
+  for (const { filePath, moduleName } of getSvelteFiles(input)) {
+    const source = await fs.readFile(filePath, "utf-8");
 
-    if (chunkOrAsset.type !== "asset" && chunkOrAsset.isEntry) {
-      exports = chunkOrAsset.exports;
-
-      for (const filePath in chunkOrAsset.modules) {
-        // options.input assumes the Rollup entry point is `index.js`
-        if (filePath.endsWith("index.js")) {
-          rendered_exports = chunkOrAsset.modules[filePath].renderedExports;
-        }
-
-        if (!/node_modules/.test(filePath)) {
-          const parsed = path.parse(filePath);
-          const moduleName = parsed.name;
-          const single_default_export = exports.length === 1 && exports[0] === "default";
-
-          if (exports.includes("default")) {
-            default_export.moduleName = moduleName;
-            default_export.only = single_default_export;
-          }
-
-          if (parsed.ext === ".svelte" && (exports.includes(moduleName) || single_default_export)) {
-            const source = await fs.readFile(filePath, "utf-8");
-            components.set(moduleName, {
-              moduleName,
-              filePath: path.relative(path.join(process.cwd(), input), filePath).replace(/\..\//g, "./"),
-              ...parser.parseSvelteComponent(source, {
-                moduleName,
-                filePath,
-              }),
-            });
-          }
-        }
-      }
-    }
+    components.set(moduleName, {
+      moduleName,
+      filePath,
+      ...parser.parseSvelteComponent(source, {
+        moduleName,
+        filePath,
+      }),
+    });
   }
 
   return {
     exports,
-    rendered_exports,
-    default_export,
     components,
   };
 }
@@ -111,13 +79,11 @@ export async function generateBundle(bundle: Rollup.OutputBundle, input: string)
 export function writeOutput(result: GenerateBundleResult, opts: PluginSveldOptions, input: string) {
   if (opts?.types !== false) {
     writeTsDefinitions(result.components, {
-      inputDir: "src",
+      inputDir: path.dirname(input),
       outDir: "types",
       preamble: "",
       ...opts?.typesOptions,
       exports: result.exports,
-      default_export: result.default_export,
-      rendered_exports: result.rendered_exports,
     });
   }
 

--- a/src/writer/writer-json.ts
+++ b/src/writer/writer-json.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import * as fs from "fs";
 import { ComponentDocApi, ComponentDocs } from "../rollup-plugin";
 import Writer from "./Writer";
 
@@ -14,13 +13,16 @@ interface JsonOutput {
 }
 
 export default async function writeJson(components: ComponentDocs, options: WriteJsonOptions) {
-  const file_path = fs.lstatSync(options.input).isDirectory() ? options.input : path.dirname(options.input);
   const output: JsonOutput = {
     total: components.size,
     components: Array.from(components, ([moduleName, component]) => ({
       ...component,
-      filePath: path.join("/", file_path, component.filePath),
-    })),
+      filePath: path.normalize(component.filePath),
+    })).sort((a, b) => {
+      if (a.moduleName < b.moduleName) return -1;
+      if (a.moduleName > b.moduleName) return 1;
+      return 0;
+    }),
   };
 
   const output_path = path.join(process.cwd(), options.outFile);

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -1,4 +1,6 @@
 import * as path from "path";
+import { convertSvelteExt, createExports } from "../create-exports";
+import { ParsedExports } from "../parse-exports";
 import { ComponentDocApi, ComponentDocs } from "../rollup-plugin";
 import Writer from "./Writer";
 
@@ -128,46 +130,21 @@ export function writeTsDefinition(component: ComponentDocApi) {
     > {}`;
 }
 
-function createExport(file_path: string, { moduleName, isDefault }: { moduleName: string; isDefault: boolean }) {
-  return `export { default as ${isDefault ? "default" : moduleName} } from "${file_path}";`;
-}
-
 export interface WriteTsDefinitionsOptions {
   outDir: string;
   inputDir: string;
   preamble: string;
-  exports: string[];
-  default_export: { moduleName: null | string; only: boolean };
-  rendered_exports: string[];
+  exports: ParsedExports;
 }
 
 export default async function writeTsDefinitions(components: ComponentDocs, options: WriteTsDefinitionsOptions) {
-  const ts_folder_path = path.join(process.cwd(), options.outDir);
-  const ts_base_path = path.join(ts_folder_path, "index.d.ts");
+  const ts_base_path = path.join(process.cwd(), options.outDir, "index.d.ts");
   const writer = new Writer({ parser: "typescript", printWidth: 120 });
-
-  let indexDTs = options.preamble;
+  const indexDTs = options.preamble + createExports(options.exports);
 
   for await (const [moduleName, component] of components) {
-    const ts_filepath = component.filePath.replace(".svelte", ".d.ts");
-    const ts_path = component.filePath.replace(".svelte", "");
-    const export_path = ts_path.startsWith("./") ? ts_path : "./" + ts_path;
-
-    if (options.default_export.moduleName == null) {
-      indexDTs += createExport(export_path, { moduleName, isDefault: false });
-    } else {
-      if (options.default_export.only) {
-        indexDTs += createExport(export_path, { moduleName, isDefault: true });
-      } else {
-        indexDTs += createExport(export_path, { moduleName, isDefault: false });
-
-        if (options.rendered_exports.includes(moduleName)) {
-          indexDTs += createExport(export_path, { moduleName, isDefault: true });
-        }
-      }
-    }
-
-    await writer.write(path.join(ts_folder_path, ts_filepath), writeTsDefinition(component));
+    const ts_filepath = convertSvelteExt(component.filePath).replace(options.inputDir, options.outDir);
+    await writer.write(ts_filepath, writeTsDefinition(component));
   }
 
   await writer.write(ts_base_path, indexDTs);

--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -139,7 +139,7 @@ export interface WriteTsDefinitionsOptions {
 
 export default async function writeTsDefinitions(components: ComponentDocs, options: WriteTsDefinitionsOptions) {
   const ts_base_path = path.join(process.cwd(), options.outDir, "index.d.ts");
-  const writer = new Writer({ parser: "typescript", printWidth: 120 });
+  const writer = new Writer({ parser: "typescript", printWidth: 80 });
   const indexDTs = options.preamble + createExports(options.exports);
 
   for await (const [moduleName, component] of components) {

--- a/tests/create-exports.test.ts
+++ b/tests/create-exports.test.ts
@@ -1,24 +1,24 @@
 import * as test from "tape";
-import { createExports } from "../src/create-exports";
+import { convertSvelteExt, createExports, removeSvelteExt } from "../src/create-exports";
 
 test("createExports – single default export", (t) => {
   const source = { default: { source: "./Component.svelte", default: true } };
 
-  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.deepEqual(createExports(source), 'export { default } from "./Component";');
   t.end();
 });
 
 test("createExports – single default export (declaration)", (t) => {
   const source = { Component: { source: "./Component.svelte", default: true } };
 
-  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.deepEqual(createExports(source), 'export { default } from "./Component";');
   t.end();
 });
 
 test("createExports – single named export", (t) => {
   const source = { Component: { source: "./Component.svelte", default: false } };
 
-  t.deepEqual(createExports(source), 'export { default as Component } from "./Component.svelte";');
+  t.deepEqual(createExports(source), 'export { default as Component } from "./Component";');
   t.end();
 });
 
@@ -30,7 +30,7 @@ test("createExports – multiple named exports", (t) => {
 
   t.deepEqual(
     createExports(source),
-    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";'
+    'export { default as Component } from "./Component";\nexport { default as Component2 } from "./Component2";'
   );
   t.end();
 });
@@ -44,7 +44,7 @@ test("createExports – multiple named exports with a default export", (t) => {
 
   t.deepEqual(
     createExports(source),
-    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component2.svelte";'
+    'export { default as Component } from "./Component";\nexport { default as Component2 } from "./Component2";\nexport { default } from "./Component2";'
   );
   t.end();
 });
@@ -58,7 +58,29 @@ test("createExports – multiple named exports with a default export (declaratio
 
   t.deepEqual(
     createExports(source),
-    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component3.svelte";'
+    'export { default as Component } from "./Component";\nexport { default as Component2 } from "./Component2";\nexport { default } from "./Component3";'
   );
+  t.end();
+});
+
+test("createExports – mixed exports", (t) => {
+  const source = { Component: { source: "./Component.svelte", default: true, mixed: true } };
+
+  t.deepEqual(
+    createExports(source),
+    'export { default as Component } from "./Component";\nexport { default } from "./Component";'
+  );
+  t.end();
+});
+
+test("removeSvelteExt", (t) => {
+  t.equal(removeSvelteExt("input.svelte"), "input");
+  t.equal(removeSvelteExt("ComponentName.svelte"), "ComponentName");
+  t.end();
+});
+
+test("convertSvelteExt", (t) => {
+  t.equal(convertSvelteExt("input.svelte"), "input.d.ts");
+  t.equal(convertSvelteExt("ComponentName.svelte"), "ComponentName.d.ts");
   t.end();
 });

--- a/tests/create-exports.test.ts
+++ b/tests/create-exports.test.ts
@@ -1,0 +1,64 @@
+import * as test from "tape";
+import { createExports } from "../src/create-exports";
+
+test("createExports – single default export", (t) => {
+  const source = { default: { source: "./Component.svelte", default: true } };
+
+  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.end();
+});
+
+test("createExports – single default export (declaration)", (t) => {
+  const source = { Component: { source: "./Component.svelte", default: true } };
+
+  t.deepEqual(createExports(source), 'export { default } from "./Component.svelte";');
+  t.end();
+});
+
+test("createExports – single named export", (t) => {
+  const source = { Component: { source: "./Component.svelte", default: false } };
+
+  t.deepEqual(createExports(source), 'export { default as Component } from "./Component.svelte";');
+  t.end();
+});
+
+test("createExports – multiple named exports", (t) => {
+  const source = {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+  };
+
+  t.deepEqual(
+    createExports(source),
+    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";'
+  );
+  t.end();
+});
+
+test("createExports – multiple named exports with a default export", (t) => {
+  const source = {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+    default: { source: "./Component2.svelte", default: true },
+  };
+
+  t.deepEqual(
+    createExports(source),
+    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component2.svelte";'
+  );
+  t.end();
+});
+
+test("createExports – multiple named exports with a default export (declaration)", (t) => {
+  const source = {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+    Component3: { source: "./Component3.svelte", default: true },
+  };
+
+  t.deepEqual(
+    createExports(source),
+    'export { default as Component } from "./Component.svelte";\nexport { default as Component2 } from "./Component2.svelte";\nexport { default } from "./Component3.svelte";'
+  );
+  t.end();
+});

--- a/tests/get-svelte-files.test.ts
+++ b/tests/get-svelte-files.test.ts
@@ -1,0 +1,18 @@
+import * as test from "tape";
+import { getSvelteFiles } from "../src/get-svelte-files";
+
+test("getSvelteFiles – file as entry", (t) => {
+  const files = getSvelteFiles("tests/integration.js");
+
+  t.equal(files.length > 0, true);
+  t.deepEqual(files[0], { filePath: "tests/snapshots/bind-this/input.svelte", moduleName: "input" });
+  t.end();
+});
+
+test("getSvelteFiles – directory as entry", (t) => {
+  const files = getSvelteFiles("tests/snapshots");
+
+  t.equal(files.length > 0, true);
+  t.deepEqual(files[0], { filePath: "tests/snapshots/bind-this/input.svelte", moduleName: "input" });
+  t.end();
+});

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -19,7 +19,7 @@ const execCwd = async (dir, ...args) => await exec(`yarn --cwd ${dir} ${args}`);
     for await (const dir of dirs) {
       await execCwd(dir, `link "${name}"`);
       await execCwd(dir, "install");
-      
+
       const build = await execCwd(dir, "build");
       process.stdout.write(build.stdout + "\n");
 

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -1,0 +1,71 @@
+import * as test from "tape";
+import { parseExports } from "../src/parse-exports";
+
+test("parseExports – single default export", (t) => {
+  const source = `export { default } from "./Component.svelte";`;
+
+  t.deepEqual(parseExports(source), { default: { source: "./Component.svelte", default: true } });
+  t.end();
+});
+
+test("parseExports – single default export (declaration)", (t) => {
+  const source = `
+    import Component from "./Component.svelte";
+    export default Component;`;
+
+  t.deepEqual(parseExports(source), {
+    Component: { source: "./Component.svelte", default: true },
+  });
+  t.end();
+});
+
+test("parseExports – single named export", (t) => {
+  const source = `export { default as Component } from "./Component.svelte";`;
+
+  t.deepEqual(parseExports(source), {
+    Component: { source: "./Component.svelte", default: false },
+  });
+  t.end();
+});
+
+test("parseExports – multiple named exports", (t) => {
+  const source = `
+    export { default as Component } from "./Component.svelte";
+    export { default as Component2 } from "./Component2.svelte";`;
+
+  t.deepEqual(parseExports(source), {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+  });
+  t.end();
+});
+
+test("parseExports – multiple named exports with a default export", (t) => {
+  const source = `
+    export { default as Component } from "./Component.svelte";
+    export { default as Component2 } from "./Component2.svelte";
+    export { default } from "./Component2.svelte";`;
+
+  t.deepEqual(parseExports(source), {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+    default: { source: "./Component2.svelte", default: true },
+  });
+  t.end();
+});
+
+test("parseExports – multiple named exports with a default export (declaration)", (t) => {
+  const source = `
+    export { default as Component } from "./Component.svelte";
+    export { default as Component2 } from "./Component2.svelte";
+
+    import Component3 from "./Component3.svelte";
+    export default Component3;`;
+
+  t.deepEqual(parseExports(source), {
+    Component: { source: "./Component.svelte", default: false },
+    Component2: { source: "./Component2.svelte", default: false },
+    Component3: { source: "./Component3.svelte", default: true },
+  });
+  t.end();
+});

--- a/tests/parse-exports.test.ts
+++ b/tests/parse-exports.test.ts
@@ -69,3 +69,14 @@ test("parseExports – multiple named exports with a default export (declaration
   });
   t.end();
 });
+
+test("parseExports – mixed exports", (t) => {
+  const source = `
+    import Component from "./Component.svelte";
+
+    export { Component };
+    export default Component;`;
+
+  t.deepEqual(parseExports(source), { Component: { source: "./Component.svelte", default: true, mixed: true } });
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,11 @@
   dependencies:
     "@types/node" "*"
 
+acorn@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
+  integrity sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.4"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.4"
+    fastq "^1.6.0"
+
 "@rollup/plugin-node-resolve@^11.0.1":
   version "11.0.1"
   resolved "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz#d3765eec4bccf960801439a999382aed2dca959b"
@@ -139,7 +160,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -391,6 +412,25 @@ estree-walker@^1.0.1:
   resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
+fast-glob@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
+fastq@^1.6.0:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz#74dbefccade964932cdf500473ef302719c652bb"
+  integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
+  dependencies:
+    reusify "^1.0.4"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -466,7 +506,7 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
-glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -475,7 +515,7 @@ glob-parent@~5.1.0:
 
 glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
@@ -751,6 +791,19 @@ meow@^3.3.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -901,7 +954,7 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -1021,6 +1074,11 @@ resumer@^0.0.0:
   dependencies:
     through "~2.3.4"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^2.6.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -1049,6 +1107,11 @@ rollup@^2.36.0:
   integrity sha512-L38QyQK77bkJy9nPyeydnHFK6xMofqumh4scTV2d4RG4EFq6pGdxnn67dVHFUDJ9J0PSEQx8zn1FiVS5TydsKg==
   optionalDependencies:
     fsevents "~2.1.2"
+
+run-parallel@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
+  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
**Changes**

- use acorn to parse base exports (should address #13 )
- use fast-glob to collect all *.svelte files from the Svelte source folder specified in `package.json#svelte`
- format TS definitions using a prettier printWidth of 80 instead of 120

**Breaking Changes**

- `filePath` in generated JSON output is relative instead of absolute (normalized using `path.normalize`)