### PR TITLE
fix(writer): omit moduleName if value is "default"

### DIFF
--- a/src/writer/writer-ts-definitions.ts
+++ b/src/writer/writer-ts-definitions.ts
@@ -147,7 +147,7 @@ export function writeTsDefinition(component: ComponentDocApi) {
   ${getTypeDefs({ typedefs })}
   ${prop_def}
 
-  export default class ${moduleName} extends SvelteComponentTyped<
+  export default class ${moduleName === 'default' ? '' : moduleName} extends SvelteComponentTyped<
       ${props_name},
       {${genEventDef({ events })}},
       {${genSlotDef({ slots })}}

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -108,3 +108,21 @@ test("writeTsDefinition", (t) => {
   );
   t.end();
 });
+
+test('writeTsDefinition – "default" module name', (t) => {
+  const component_api: ComponentDocApi = {
+    moduleName: "default",
+    filePath: "./src/ModuleName.svelte",
+    props: [],
+    slots: [],
+    events: [],
+    typedefs: [],
+    rest_props: undefined,
+  };
+
+  t.equal(
+    writeTsDefinition(component_api),
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface defaultProps  {\n      \n    }\n  \n\n  export default class  extends SvelteComponentTyped<\n      defaultProps,\n      {},\n      {}\n    > {\n      \n    }'
+  );
+  t.end();
+});


### PR DESCRIPTION
**Fixes**

- fix(writer): omit `moduleName` if value is "default" in generated TypeScript class export