### PR TITLE
fix: write constant props as accessors in SvelteComponentTyped

### DIFF
--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -77,17 +77,12 @@ export async function generateBundle(input: string, glob: boolean) {
     const filePath = entry.source,
       ext = path.parse(filePath).ext;
 
-    if (ext === '.svelte') {
+    if (ext === ".svelte") {
       const source = await fs.readFile(path.resolve(dir, filePath), "utf-8");
 
-      const { code: processed } = await preprocess(
-        source,
-        [
-          typescript(),
-          replace([[/<style.+<\/style>/gims, ""]]),
-        ],
-        { filename: path.basename(filePath) }
-      );
+      const { code: processed } = await preprocess(source, [typescript(), replace([[/<style.+<\/style>/gims, ""]])], {
+        filename: path.basename(filePath),
+      });
 
       components.set(moduleName, {
         moduleName,

--- a/tests/snapshots/function-declaration/output.d.ts
+++ b/tests/snapshots/function-declaration/output.d.ts
@@ -6,19 +6,23 @@ export interface InputProps {
    * @default () => {}
    */
   fnA?: () => {};
+}
 
+export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
   /**
    * @constant
    * @default () => {}
    */
-  fnB?: () => {};
-}
+  fnB: () => {};
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, {}> {
+  /**
+   * @default () => { return a + b; }
+   */
   add: () => any;
 
   /**
    * Multiplies two numbers
+   * @default () => { return a * b; }
    */
   multiply: (a: number, b: number) => number;
 }

--- a/tests/snapshots/infer-basic/output.d.ts
+++ b/tests/snapshots/infer-basic/output.d.ts
@@ -23,14 +23,17 @@ export interface InputProps {
    * @default "" + Math.random().toString(36)
    */
   id?: string;
+}
 
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
   /**
    * @constant
    * @default { ["1"]: true }
    */
-  propConst?: { ["1"]: true };
-}
+  propConst: { ["1"]: true };
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
+  /**
+   * @default () => { localBool = !localBool; }
+   */
   fn: () => any;
 }

--- a/tests/snapshots/infer-with-types/output.d.ts
+++ b/tests/snapshots/infer-with-types/output.d.ts
@@ -18,14 +18,17 @@ export interface InputProps {
    * @default "" + Math.random().toString(36)
    */
   id?: string;
+}
 
+export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
   /**
    * @constant
    * @default { ["1"]: true }
    */
-  propConst?: { ["1"]: true };
-}
+  propConst: { [key: string]: boolean };
 
-export default class Input extends SvelteComponentTyped<InputProps, {}, { default: {} }> {
+  /**
+   * @default () => { localBool = !localBool; }
+   */
   fn: () => any;
 }

--- a/tests/writer-ts-definitions.test.ts
+++ b/tests/writer-ts-definitions.test.ts
@@ -104,7 +104,7 @@ test("writeTsDefinition", (t) => {
 
   t.equal(
     writeTsDefinition(component_api),
-    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @constant\n* @default { ["1"]: true }\n*/\n      propConst?: { ["1"]: true };\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n\n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    }'
+    '\n  /// <reference types="svelte" />\n  import { SvelteComponentTyped } from "svelte";\n  \n  \n  \n    export interface ModuleNameProps  {\n      \n      /**\n* @default true\n*/\n      propBool?: boolean;\n\n      /**\n* @default ""\n*/\n      propString?: string;\n\n      \n      name?: string;\n\n      /**\n* @default "" + Math.random().toString(36)\n*/\n      id?: string;\n\n      /**\n* @default () => { localBool = !localBool; }\n*/\n      fn?: () => {     localBool = !localBool;   };\n    }\n  \n\n  export default class ModuleName extends SvelteComponentTyped<\n      ModuleNameProps,\n      {},\n      {default: {}\n;}\n    > {\n      \n    /**\n* @constant\n* @default { ["1"]: true }\n*/\n    propConst: { [key: string]: boolean; };\n    }'
   );
   t.end();
 });


### PR DESCRIPTION
**Fixes**

- write constant props as accessors in the `SvelteComponentTyped` interface