### PR TITLE
Fix backslashes in js export (#38)

### DIFF
--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -63,11 +63,11 @@ export async function generateBundle(input: string, glob: boolean) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");
       let source = "./" + path.relative(dir, file);
-      console.log("generateBundle1", source);
+
       if (path.sep !== "/") {
         source = source.split(path.sep).join("/");
       }
-      console.log("generateBundle2", source);
+
       if (exports[moduleName]) {
         exports[moduleName].source = source;
       }

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -58,7 +58,6 @@ export async function generateBundle(input: string, glob: boolean) {
   const dir = fs.lstatSync(input).isFile() ? path.dirname(input) : input;
   const entry = fs.readFileSync(input, "utf-8");
   const exports = parseExports(entry);
-  console.log("generateBundle");
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -62,8 +62,10 @@ export async function generateBundle(input: string, glob: boolean) {
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");
-      const source = "./" + path.relative(dir, file);
-
+      let source = "./" + path.relative(dir, file);
+      if (path.sep !== "/") {
+        source = source.replace(path.sep, "/");
+      }
       if (exports[moduleName]) {
         exports[moduleName].source = source;
       }

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -66,6 +66,7 @@ export async function generateBundle(input: string, glob: boolean) {
       if (path.sep !== "/") {
         source = source.replace(path.sep, "/");
       }
+      
       if (exports[moduleName]) {
         exports[moduleName].source = source;
       }

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -58,7 +58,7 @@ export async function generateBundle(input: string, glob: boolean) {
   const dir = fs.lstatSync(input).isFile() ? path.dirname(input) : input;
   const entry = fs.readFileSync(input, "utf-8");
   const exports = parseExports(entry);
-  
+
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -58,6 +58,7 @@ export async function generateBundle(input: string, glob: boolean) {
   const dir = fs.lstatSync(input).isFile() ? path.dirname(input) : input;
   const entry = fs.readFileSync(input, "utf-8");
   const exports = parseExports(entry);
+  
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");

--- a/src/rollup-plugin.ts
+++ b/src/rollup-plugin.ts
@@ -58,15 +58,16 @@ export async function generateBundle(input: string, glob: boolean) {
   const dir = fs.lstatSync(input).isFile() ? path.dirname(input) : input;
   const entry = fs.readFileSync(input, "utf-8");
   const exports = parseExports(entry);
-
+  console.log("generateBundle");
   if (glob) {
     fg.sync([`${dir}/**/*.svelte`]).forEach((file) => {
       const moduleName = path.parse(file).name.replace(/\-/g, "");
       let source = "./" + path.relative(dir, file);
+      console.log("generateBundle1", source);
       if (path.sep !== "/") {
-        source = source.replace(path.sep, "/");
+        source = source.split(path.sep).join("/");
       }
-      
+      console.log("generateBundle2", source);
       if (exports[moduleName]) {
         exports[moduleName].source = source;
       }


### PR DESCRIPTION
In case this is run on Windows, (`path.sep` will be a backslash), this will now replace those backslashes with slashes for e.g. `types/index.d.ts`.
Without this PR, running `npm run test:integration` will generate an invalid `types/index.d.ts`. With this PR, this will be fixed.